### PR TITLE
Add `DerivePhalaI2pKey()` rpc method

### DIFF
--- a/pruntime_rpc.proto
+++ b/pruntime_rpc.proto
@@ -41,6 +41,13 @@ service PhactoryAPI {
   // Get given worker's state from a GK.
   rpc GetWorkerState (GetWorkerStateRequest) returns (WorkerState) {}
 
+  // Init the endpoint
+  rpc InitEndpoint (InitEndpointRequest) returns (InitEndpointResponse) {}
+
+  // Get endpoint info
+  rpc GetEndpointInfo (google.protobuf.Empty) returns (InitEndpointResponse) {}
+
+  // Get prouter private key
   rpc DerivePhalaI2pKey (google.protobuf.Empty) returns (DerivePhalaI2pKeyResponse) {}
 
   // A echo rpc to measure network RTT.
@@ -311,6 +318,18 @@ enum ResponsiveEvent {
   NoEvent = 0;
   EnterUnresponsive = 1;
   ExitUnresponsive = 2;
+}
+
+message InitEndpointRequest {
+  // @codec scale phala_types::EndpointType
+  bytes encoded_endpoint_type = 1;
+  bytes endpoint = 2;
+}
+
+message InitEndpointResponse {
+  // @codec scale phala_types::VersionedWorkerEndpoint
+  bytes encoded_versioned_endpoint = 1;
+  optional bytes signature = 2;
 }
 
 message DerivePhalaI2pKeyResponse {

--- a/pruntime_rpc.proto
+++ b/pruntime_rpc.proto
@@ -40,9 +40,8 @@ service PhactoryAPI {
 
   // Get given worker's state from a GK.
   rpc GetWorkerState (GetWorkerStateRequest) returns (WorkerState) {}
-  
-  // Get derived identity keypair for downstream usage (e.g. PRouter)
-  rpc DeriveIdentSk (DeriveIdentSkRequest) returns (DeriveIdentSkResponse) {}
+
+  rpc DerivePhalaI2pKey (google.protobuf.Empty) returns (DerivePhalaI2pKeyResponse) {}
 
   // A echo rpc to measure network RTT.
   rpc Echo (EchoMessage) returns (EchoMessage) {}
@@ -295,14 +294,6 @@ message MiningState {
   uint64 start_time = 3;
 }
 
-message DeriveIdentSkRequest {
-  bytes info = 1;
-}
-
-message DeriveIdentSkResponse {
-  bytes sk = 1;
-}
-
 message EchoMessage {
   bytes echo_msg = 1;
 }
@@ -311,6 +302,10 @@ enum ResponsiveEvent {
   NoEvent = 0;
   EnterUnresponsive = 1;
   ExitUnresponsive = 2;
+}
+
+message DerivePhalaI2pKeyResponse {
+  bytes phala_i2p_key = 1;
 }
 
 message TokenomicInfo {

--- a/pruntime_rpc.proto
+++ b/pruntime_rpc.proto
@@ -40,6 +40,9 @@ service PhactoryAPI {
 
   // Get given worker's state from a GK.
   rpc GetWorkerState (GetWorkerStateRequest) returns (WorkerState) {}
+  
+  // Get derived identity keypair for downstream usage (e.g. PRouter)
+  rpc DeriveIdentSk (DeriveIdentSkRequest) returns (DeriveIdentSkResponse) {}
 
   // A echo rpc to measure network RTT.
   rpc Echo (EchoMessage) returns (EchoMessage) {}
@@ -290,6 +293,14 @@ message MiningState {
   uint32 session_id = 1;
   bool paused = 2;
   uint64 start_time = 3;
+}
+
+message DeriveIdentSkRequest {
+  bytes info = 1;
+}
+
+message DeriveIdentSkResponse {
+  bytes sk = 1;
 }
 
 message EchoMessage {


### PR DESCRIPTION
Add `DeriveIdentSk()` rpc method for downstream usage (e.g. PRouter).