### PR TITLE
Remove field running_sidetasks from get_info

### DIFF
--- a/pruntime_rpc.proto
+++ b/pruntime_rpc.proto
@@ -121,8 +121,6 @@ message PhactoryInfo {
   string version = 15;
   // The git commit hash which this binary was built from
   string git_revision = 16;
-  // The number of running side tasks
-  uint64 running_side_tasks = 17;
   // The heap memory usage of the enclave.
   MemoryUsage memory_usage = 18;
   // Some relay chain header synced, waiting for parachain headers.


### PR DESCRIPTION
SideTask is being removed in https://github.com/Phala-Network/phala-blockchain/pull/995.